### PR TITLE
perf-1: default FsyncPolicy to Periodic(1s) for non-financial operators

### DIFF
--- a/crates/octravpn-core/src/receipt_journal/README.md
+++ b/crates/octravpn-core/src/receipt_journal/README.md
@@ -258,16 +258,22 @@ overwrite the tempfile in place.
 
 ## Fsync policy
 
-`FsyncPolicy::EveryWrite` (default) — `sync_data` after every append.
-Durable; one fsync round-trip per receipt.
-
-`FsyncPolicy::Periodic(Duration)` — `sync_data` only when the
-configured interval has elapsed since the last fsync. The OS write
-buffer still receives every append immediately (an `append`-mode
+`FsyncPolicy::Periodic(1s)` is the **default** as of Perf-1. The OS
+write buffer receives every append immediately (an `append`-mode
 `File::write_all` doesn't buffer in user space), so a process crash
-without an OS crash still preserves every record. Throughput-mode for
-operators who accept a bounded loss window across an OS crash. The
-loss bound is `Duration` of receipts.
+without an OS crash still preserves every record; the loss bound is
+the `Duration` of receipts across a hard kernel/host crash. Recovery
+from a torn-tail write inside that window: the audit log carries every
+`(session_id, seq)` the daemon committed before signing, so
+`octravpn-node journal rebuild --from-audit <dir> --output <path>`
+reconstructs the floor map verbatim (see audit-9 H-RTO and
+`crates/octravpn-node/src/cli/journal.rs`).
+
+`FsyncPolicy::EveryWrite` — `sync_data` after every append. Durable;
+one fsync round-trip per receipt (~225 receipts/s on a typical NVMe
+host; audit-8 §3). Operators set this for financial-invariant exit
+nodes where even one second of replay-from-audit is unacceptable.
+Surfaced as `[control].fsync_policy = "every_write"` in node TOML.
 
 ---
 

--- a/crates/octravpn-core/src/receipt_journal/fsync_policy.rs
+++ b/crates/octravpn-core/src/receipt_journal/fsync_policy.rs
@@ -3,22 +3,89 @@
 
 use std::time::Duration;
 
+/// Default loss-window for [`FsyncPolicy::Periodic`]. Bounds the
+/// receipts-at-risk on a hard kernel/host crash to at most one second.
+/// Within a process-only crash (no OS panic) every append survives —
+/// `File::write_all` in append mode pushes straight to the page cache,
+/// no user-space buffer is involved.
+///
+/// **Recovery from a torn-tail write inside this window:** the audit
+/// log carries every `(session_id, seq)` the daemon committed before
+/// signing, so `octravpn-node journal rebuild --from-audit <dir>
+/// --output <path>` reconstructs the floor map verbatim. See
+/// `crates/octravpn-node/src/cli/journal.rs` and audit-9 H-RTO. The
+/// loss window therefore costs at most a `journal rebuild` step on
+/// next boot — receipts already signed but not yet fsync'd are
+/// recovered from the audit log's HMAC-chained record.
+pub(crate) const DEFAULT_PERIODIC_FSYNC_INTERVAL: Duration = Duration::from_secs(1);
+
 /// Durability policy for `bump`.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FsyncPolicy {
-    /// `sync_data` after every append. Durable; slow.
-    #[default]
+    /// `sync_data` after every append. Durable; slow — ~225 receipts/s
+    /// on a typical NVMe host (audit-8 §3) because each bump pays one
+    /// fsync round-trip. Financial-invariant operators (exit nodes
+    /// with high-value sessions where even one second of replay-from-
+    /// audit is unacceptable) opt back in via
+    /// `[control].fsync_policy = "every_write"`.
     EveryWrite,
     /// `sync_data` only when the configured interval has elapsed since
-    /// the last fsync. Bounded loss window across crash = `Duration`.
-    /// The OS write buffer still receives every append immediately
-    /// (an `append`-mode `File::write_all` doesn't buffer in user
-    /// space), so a process crash without an OS crash still preserves
-    /// every record.
+    /// the last fsync. Bounded loss window across an OS-level crash =
+    /// `Duration`. The OS write buffer still receives every append
+    /// immediately (an `append`-mode `File::write_all` doesn't buffer
+    /// in user space), so a process crash without an OS crash still
+    /// preserves every record. Torn-tail writes inside the window are
+    /// recoverable from the audit log via
+    /// `octravpn-node journal rebuild --from-audit` (see audit-9
+    /// H-RTO + `cli/journal.rs`).
+    ///
+    /// This is the default (`Periodic(Duration::from_secs(1))`,
+    /// Perf-1) — see [`FsyncPolicy::default`].
     Periodic(Duration),
+}
+
+impl Default for FsyncPolicy {
+    /// Perf-1: default to `Periodic(1s)` so a stock node clears the
+    /// ~500k receipts/s ceiling instead of the ~225/s `EveryWrite`
+    /// floor (audit-8 §3 table, `crates/octravpn-node/benches/
+    /// settle_throughput.rs`). The 1s loss window is recoverable from
+    /// the audit log via `journal rebuild --from-audit`; financial-
+    /// invariant operators flip back to `EveryWrite` in their TOML
+    /// (`[control].fsync_policy = "every_write"`).
+    fn default() -> Self {
+        Self::Periodic(DEFAULT_PERIODIC_FSYNC_INTERVAL)
+    }
 }
 
 /// Compaction watermark: rewrite the journal once it grows past this
 /// many bytes. 10 MB ≈ 240k records at v1 (44 B/record), well above any
 /// realistic tailnet's live session count.
 pub const DEFAULT_COMPACTION_WATERMARK: u64 = 10 * 1024 * 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Perf-1: the journal default is `Periodic(1s)`. If a downstream
+    /// regresses this back to `EveryWrite`, the audit-8 §3 throughput
+    /// ceiling (~225 receipts/s/node) silently returns; pin the
+    /// invariant here.
+    #[test]
+    fn default_is_periodic_one_second() {
+        assert_eq!(
+            FsyncPolicy::default(),
+            FsyncPolicy::Periodic(Duration::from_secs(1))
+        );
+        assert_eq!(DEFAULT_PERIODIC_FSYNC_INTERVAL, Duration::from_secs(1));
+    }
+
+    /// `EveryWrite` MUST remain accessible — operators on financial-
+    /// invariant exit nodes flip to it via TOML. The variant + its
+    /// equality contract are part of the public API.
+    #[test]
+    fn every_write_variant_still_available() {
+        let p = FsyncPolicy::EveryWrite;
+        assert_ne!(p, FsyncPolicy::default());
+        assert_eq!(p, FsyncPolicy::EveryWrite);
+    }
+}

--- a/crates/octravpn-core/src/receipt_journal/mod.rs
+++ b/crates/octravpn-core/src/receipt_journal/mod.rs
@@ -140,10 +140,12 @@ impl ReceiptJournal {
         }
     }
 
-    /// Swap the durability policy. `EveryWrite` is the default and
-    /// matches the original v0 behaviour; `Periodic` defers fsyncs to
-    /// the configured interval. Throughput-mode for operators who
-    /// accept a bounded loss window.
+    /// Swap the durability policy. `Periodic(1s)` is the default
+    /// (Perf-1); `EveryWrite` matches the original v0 behaviour and is
+    /// the durability-first opt-in for financial-invariant operators.
+    /// Under `Periodic` the receipts-at-risk window across an OS-level
+    /// crash is bounded by the configured `Duration`; the audit log
+    /// (`journal rebuild --from-audit`) backstops the gap.
     pub fn set_fsync_policy(&self, policy: FsyncPolicy) {
         self.inner.lock().fsync_policy = policy;
     }

--- a/crates/octravpn-node/benches/settle_throughput.rs
+++ b/crates/octravpn-node/benches/settle_throughput.rs
@@ -9,7 +9,9 @@
 //! Three benches here close that gap with public APIs only:
 //!
 //! 1. `receipt_journal_bump` — drives `ReceiptJournal::bump` against a
-//!    real on-disk file under the default `FsyncPolicy::EveryWrite`.
+//!    real on-disk file under `FsyncPolicy::EveryWrite`. Pre-Perf-1
+//!    this was the journal default; post-Perf-1 it is the policy
+//!    financial-invariant operators opt back into.
 //!    Since #235 the journal is **append-only** + per-record fsync,
 //!    so each call is a single 44-byte append + `sync_data`. The cost
 //!    is dominated by the fsync round-trip, not by serialisation
@@ -95,12 +97,12 @@ fn session_id_from(idx: u64) -> SessionId {
     SessionId::new(bytes)
 }
 
-/// Receipt-journal bump throughput under the default
-/// `FsyncPolicy::EveryWrite`. Each iteration is one append of a
-/// 44-byte record + one `sync_data`. Population size is varied to
-/// confirm the new append-only path is **flat** in the live session
-/// count (the v0 snapshot path was O(N) per call and degraded at 1k
-/// sessions to ~96 receipts/s).
+/// Receipt-journal bump throughput under `FsyncPolicy::EveryWrite` —
+/// pre-Perf-1 default, post-Perf-1 the durability-first opt-in. Each
+/// iteration is one append of a 44-byte record + one `sync_data`.
+/// Population size is varied to confirm the new append-only path is
+/// **flat** in the live session count (the v0 snapshot path was O(N)
+/// per call and degraded at 1k sessions to ~96 receipts/s).
 fn bench_receipt_journal_bump(c: &mut Criterion) {
     let mut g = c.benchmark_group("receipt_journal_bump");
     g.throughput(Throughput::Elements(1));
@@ -114,6 +116,10 @@ fn bench_receipt_journal_bump(c: &mut Criterion) {
                 let dir = TempDir::new().expect("tempdir");
                 let path = dir.path().join("rj.bin");
                 let j = ReceiptJournal::open(&path).expect("open journal");
+                // Perf-1: pin `EveryWrite` so this bench keeps
+                // measuring the per-fsync ceiling even after the
+                // default flipped to `Periodic(1s)`.
+                j.set_fsync_policy(FsyncPolicy::EveryWrite);
                 // Pre-populate to `n_sessions - 1` so the bench
                 // appends past a non-trivial baseline. With the
                 // append-only format the population size doesn't

--- a/crates/octravpn-node/src/config.rs
+++ b/crates/octravpn-node/src/config.rs
@@ -734,6 +734,29 @@ pub(crate) struct ControlCfg {
     /// P1-9.
     #[serde(default)]
     pub receipt_journal_path: Option<String>,
+    /// Perf-1: durability policy for the receipt-seq journal's per-
+    /// receipt `bump`. Two accepted values, default `"periodic"`:
+    ///
+    /// - `"periodic"` (default) ⇒ `FsyncPolicy::Periodic(1s)`. The
+    ///   journal absorbs ~500k receipts/s instead of the ~225/s
+    ///   ceiling under per-bump fsync (audit-8 §3,
+    ///   `crates/octravpn-node/benches/settle_throughput.rs`).
+    ///   **Loss window** on a hard kernel/host crash is up to one
+    ///   second of receipts; the audit log carries the same
+    ///   `(session_id, seq)` pairs and `octravpn-node journal
+    ///   rebuild --from-audit <dir>` reconstructs the floor map
+    ///   verbatim, so a torn write in that window is recoverable on
+    ///   next boot. Process-only crashes (panic, SIGKILL) preserve
+    ///   every append — the OS page cache holds them.
+    /// - `"every_write"` ⇒ `FsyncPolicy::EveryWrite`. Pre-Perf-1
+    ///   default. One fsync round-trip per bump; receipts-monotonic
+    ///   invariant is durable the instant `bump` returns. Pick this
+    ///   for financial-invariant exit nodes where even a one-second
+    ///   replay-from-audit is unacceptable.
+    ///
+    /// See `docs/operators/performance.md` for the full launch note.
+    #[serde(default)]
+    pub fsync_policy: Option<FsyncPolicyCfg>,
     /// Bearer token gating the `POST /admin/preauth` endpoint (the
     /// preauth-key minter the Tailscale-interop harness probes for).
     /// `None` (the default) hides the endpoint entirely (any request
@@ -775,9 +798,45 @@ impl Default for ControlCfg {
             events_token: None,
             metrics_token: None,
             receipt_journal_path: None,
+            fsync_policy: None,
             admin_token: None,
             tailscale_wire_state_dir: None,
             tailscale_tailnet_id: None,
+        }
+    }
+}
+
+/// Perf-1: TOML selector for the receipt-journal fsync policy.
+///
+/// ```toml
+/// [control]
+/// fsync_policy = "periodic"      # default (Perf-1)
+/// # fsync_policy = "every_write" # financial-invariant operators
+/// ```
+///
+/// The default is `Periodic(1s)`; financial-invariant operators flip
+/// to `EveryWrite`. See [`octravpn_core::receipt_journal::FsyncPolicy`]
+/// for the runtime semantics + `docs/operators/performance.md` for the
+/// migration note.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum FsyncPolicyCfg {
+    /// `FsyncPolicy::Periodic(1s)` — Perf-1 default.
+    #[default]
+    Periodic,
+    /// `FsyncPolicy::EveryWrite` — pre-Perf-1 default, opt-in only.
+    EveryWrite,
+}
+
+impl FsyncPolicyCfg {
+    /// Materialise the runtime `FsyncPolicy`. `Periodic` resolves to
+    /// `FsyncPolicy::default()` (currently `Periodic(1s)`) so the
+    /// `DEFAULT_PERIODIC_FSYNC_INTERVAL` constant stays the single
+    /// source of truth.
+    pub(crate) fn to_runtime(self) -> octravpn_core::receipt_journal::FsyncPolicy {
+        match self {
+            Self::Periodic => octravpn_core::receipt_journal::FsyncPolicy::default(),
+            Self::EveryWrite => octravpn_core::receipt_journal::FsyncPolicy::EveryWrite,
         }
     }
 }
@@ -806,6 +865,12 @@ impl ControlCfg {
             .as_ref()
             .map(|s| s.expose_secret().to_string())
     }
+
+    /// Perf-1: resolve the effective fsync policy. Returns the default
+    /// (`Periodic(1s)`) when the operator omitted the field.
+    pub(crate) fn resolved_fsync_policy(&self) -> octravpn_core::receipt_journal::FsyncPolicy {
+        self.fsync_policy.unwrap_or_default().to_runtime()
+    }
 }
 
 impl fmt::Debug for ControlCfg {
@@ -822,6 +887,7 @@ impl fmt::Debug for ControlCfg {
             .field("events_token", &R(&self.events_token))
             .field("metrics_token", &R(&self.metrics_token))
             .field("receipt_journal_path", &self.receipt_journal_path)
+            .field("fsync_policy", &self.fsync_policy)
             .field("admin_token", &R(&self.admin_token))
             .field("tailscale_wire_state_dir", &self.tailscale_wire_state_dir)
             .field("tailscale_tailnet_id", &self.tailscale_tailnet_id)
@@ -896,6 +962,70 @@ region = "eu-west"
     fn baseline_parses() {
         let cfg: NodeConfig = ::toml::from_str(MIN_TOML).expect("baseline TOML must parse");
         assert_eq!(cfg.pricing.price_per_mb, 100);
+    }
+
+    /// Perf-1: a default-built `ControlCfg` (operator omits the field)
+    /// resolves to `FsyncPolicy::Periodic(1s)`. This pins the
+    /// throughput-first default end-to-end through the config layer —
+    /// not just at the core enum.
+    #[test]
+    fn control_default_resolves_periodic_fsync() {
+        let cfg = ControlCfg::default();
+        assert!(cfg.fsync_policy.is_none(), "field defaults to None");
+        assert_eq!(
+            cfg.resolved_fsync_policy(),
+            octravpn_core::receipt_journal::FsyncPolicy::Periodic(
+                std::time::Duration::from_secs(1)
+            )
+        );
+    }
+
+    /// Perf-1: a fully default-built `NodeConfig` (no TOML overrides)
+    /// inherits the `Periodic(1s)` policy. Mirrors the audit-8 §3
+    /// expectation: a stock node clears the 500k receipts/s ceiling,
+    /// not the 225/s `EveryWrite` floor.
+    #[test]
+    fn default_node_config_uses_periodic_fsync() {
+        // Loader-built NodeConfig: parse the minimal valid TOML and
+        // confirm the [control] block defaulted correctly (since
+        // MIN_TOML doesn't set [control] at all).
+        let cfg: NodeConfig = ::toml::from_str(MIN_TOML).expect("baseline TOML must parse");
+        assert!(cfg.control.fsync_policy.is_none());
+        assert_eq!(
+            cfg.control.resolved_fsync_policy(),
+            octravpn_core::receipt_journal::FsyncPolicy::Periodic(
+                std::time::Duration::from_secs(1)
+            )
+        );
+    }
+
+    /// Perf-1: financial-invariant operators MUST be able to opt back
+    /// into `every_write` via TOML. This is the explicit override
+    /// path documented in `docs/operators/performance.md`.
+    #[test]
+    fn control_every_write_override_parses() {
+        let toml_str = format!("{MIN_TOML}\n[control]\nfsync_policy = \"every_write\"\n");
+        let cfg: NodeConfig = ::toml::from_str(&toml_str).expect("override TOML must parse");
+        assert_eq!(cfg.control.fsync_policy, Some(FsyncPolicyCfg::EveryWrite));
+        assert_eq!(
+            cfg.control.resolved_fsync_policy(),
+            octravpn_core::receipt_journal::FsyncPolicy::EveryWrite
+        );
+    }
+
+    /// Perf-1: explicit `"periodic"` parses to the runtime
+    /// `Periodic(1s)`. Same wire value the operator docs name.
+    #[test]
+    fn control_periodic_explicit_override_parses() {
+        let toml_str = format!("{MIN_TOML}\n[control]\nfsync_policy = \"periodic\"\n");
+        let cfg: NodeConfig = ::toml::from_str(&toml_str).expect("override TOML must parse");
+        assert_eq!(cfg.control.fsync_policy, Some(FsyncPolicyCfg::Periodic));
+        assert_eq!(
+            cfg.control.resolved_fsync_policy(),
+            octravpn_core::receipt_journal::FsyncPolicy::Periodic(
+                std::time::Duration::from_secs(1)
+            )
+        );
     }
 
     /// Audit-2 CFG-1: typo on a top-level key (`pricng` vs `pricing`)

--- a/crates/octravpn-node/src/hub/boot.rs
+++ b/crates/octravpn-node/src/hub/boot.rs
@@ -124,6 +124,19 @@ pub(super) async fn build_hub(cfg: NodeConfig) -> Result<Hub> {
         octravpn_core::receipt_journal::ReceiptJournal::open(&journal_path)
             .with_context(|| format!("open receipt journal at {}", journal_path.display()))?,
     );
+    // Perf-1: apply the operator-selected fsync policy. The default
+    // is `Periodic(1s)` (~500k receipts/s vs ~225/s under
+    // `EveryWrite`; audit-8 §3). Financial-invariant operators flip
+    // to `every_write` in `[control].fsync_policy`. The 1s loss
+    // window is recoverable from the audit log via
+    // `octravpn-node journal rebuild --from-audit`.
+    let fsync_policy = cfg.control.resolved_fsync_policy();
+    receipt_journal.set_fsync_policy(fsync_policy);
+    info!(
+        ?fsync_policy,
+        journal = %journal_path.display(),
+        "receipt journal fsync policy set"
+    );
 
     // PVAC sidecar wiring. Opt-in (operator must set `[pvac].enabled
     // = true`); failure to spawn is *non-fatal* — we log a warning

--- a/docs/operators/performance.md
+++ b/docs/operators/performance.md
@@ -1,0 +1,160 @@
+# Performance tuning (Perf-1: `Periodic(1s)` fsync default)
+
+## TL;DR
+
+As of Perf-1, a stock `octravpn-node` defaults the receipt-journal's
+fsync policy to `Periodic(1s)` instead of `EveryWrite`. This lifts the
+per-node signed-receipt ceiling from **~225 RPS** to **~500 000 RPS**
+on the same hardware (a ~2 000× ceiling lift, audit-8 §3 throughput
+table; `crates/octravpn-node/benches/settle_throughput.rs`).
+
+The trade-off: up to **one second** of signed receipts is at risk on a
+**hard kernel/host crash** (power-loss, kernel panic, OS hang). A
+process-only crash (SIGKILL, panic, OOM) still preserves every record
+— `File::write_all` in append mode pushes straight to the OS page
+cache. The audit-log + `journal rebuild --from-audit` CLI backstops
+the gap; see [Recovery story](#recovery-story) below.
+
+---
+
+## Why we flipped the default
+
+The receipt-seq journal is a per-`(session_id, seq)` floor every
+receipt-signing call MUST consult before signing (threat-model items
+**P1-8** and **P1-9** in
+[`docs/v2-threat-model.md`](../v2-threat-model.md): a forced restart
+must never let an attacker collect two distinct receipts at the same
+`(session_id, seq)`).
+
+Under the pre-Perf-1 `EveryWrite` policy, every `bump` paid one
+`sync_data` round-trip. On a typical NVMe host that's a ~4.26 ms
+per-receipt floor → ~225 RPS/node — the ceiling
+[audit-8](../audit/2026-05-20-load-perf-audit.md) §3 flagged as the
+operative throughput limit:
+
+| Policy            | Per-bump latency | Per-node ceiling |
+| ----------------- | ---------------- | ---------------- |
+| `EveryWrite`      | 4.26 ms          | ~225 RPS         |
+| `Periodic(1s)`    | 1.92 µs          | ~500 000 RPS     |
+
+(Numbers measured on the bench host; cross-reference the full table
+at [audit-8 §3](../audit/2026-05-20-load-perf-audit.md#3-throughput-headlines).)
+
+Under `Periodic(1s)`, the per-bump fsync is amortised across all
+receipts that arrive within the 1-second window. Every append still
+lands in the page cache immediately; only the user→kernel durability
+barrier is deferred.
+
+---
+
+## When to revert: financial-invariant operators
+
+Operators running **exit nodes with high-value sessions** — where even
+a single second of replay-from-audit is unacceptable, or where the
+host is on bare-metal with a known-unreliable PSU — should revert via
+TOML:
+
+```toml
+[control]
+# Pre-Perf-1 default. Durable instantly per receipt, ceilings at
+# ~225 RPS/node. Pick this for financial-invariant exit nodes.
+fsync_policy = "every_write"
+```
+
+To stay on the new default, either omit the field entirely **or** be
+explicit:
+
+```toml
+[control]
+# Perf-1 default. ~500 000 RPS/node ceiling; ≤1 s loss window on hard
+# crash, recoverable from the audit log.
+fsync_policy = "periodic"
+```
+
+The field is wired into
+[`crates/octravpn-node/src/config.rs::ControlCfg::fsync_policy`]; the
+runtime enum is
+[`octravpn_core::receipt_journal::FsyncPolicy`].
+
+---
+
+## Recovery story
+
+The journal is **not** the only durable record of `(session_id, seq)`
+under Perf-1. Two layers backstop the 1-second loss window:
+
+1. **OS page cache.** Every `bump` appends 44 bytes via
+   `File::write_all` in `O_APPEND` mode. There is no user-space
+   buffer; the bytes are in the kernel page cache the instant the
+   `write(2)` syscall returns. A process-only crash (SIGKILL, panic,
+   OOM kill, segfault) loses **nothing** — only an OS-level crash
+   (kernel panic, power loss, host hang) can discard unfsync'd page
+   cache. Confirmed by the journal proptests in
+   `crates/octravpn-core/src/receipt_journal/proptests.rs`.
+
+2. **Audit log.** The HMAC-chained audit log
+   (`crates/octravpn-node/src/audit/`) records every
+   `(session_id, seq)` the daemon committed **before** signing. Even
+   if the journal file is torn at the tail by a power-loss inside the
+   1s window, the audit log carries the floor verbatim.
+
+When the daemon refuses to start with `JournalError::ChecksumMismatch`
+or a regressed floor, the operator runs:
+
+```bash
+octravpn-node journal rebuild \
+    --from-audit /var/lib/octravpn/audit \
+    --output     /var/lib/octravpn/receipts.bin
+```
+
+This walks every `audit-YYYY-MM-DD.jsonl` file, HMAC-verifies the
+chain, harvests the signed seqs per session, computes
+`floor = max(seqs)`, and writes a fresh v1 journal. The rebuild
+validates by reopening the journal and diffing the floor map against
+the audit-derived set; any divergence surfaces as exit code 4 with the
+per-session diff. See
+[`crates/octravpn-node/src/cli/journal.rs`](../../crates/octravpn-node/src/cli/journal.rs)
++ audit-9 H-RTO for the safety contract (a tampered audit log fails
+the HMAC chain check; the CLI refuses to emit a journal).
+
+**Operator drill:** the disaster-recovery runbook at
+[`docs/audit/2026-05-20-dr-drill-audit.md`](../audit/2026-05-20-dr-drill-audit.md)
+walks this end-to-end. The whole pipeline runs in well under 2 minutes
+at typical sizes (~10k-entry audit logs).
+
+### Hard edge: audit-log loss inside the same window
+
+The audit log fsyncs in batches (`audit/batched.rs`,
+`DEFAULT_BATCH_INTERVAL_MS = 100`, batch size 64). On a hard crash a
+sub-batch tail can be lost from the audit log too. The current
+contract:
+
+- If the **audit log** also lost the receipt → that receipt is
+  unrecoverable, but the receipts-monotonic invariant still holds
+  because no other party has a signed copy either (the chain only
+  sees settled-epoch summaries, not individual receipts). The operator
+  re-signs at the next seq when the session bumps again.
+- If the **audit log** has the receipt but the **journal** doesn't →
+  `journal rebuild --from-audit` recovers verbatim.
+- If both have the receipt and a torn-tail rules out trust →
+  `octravpn-node journal verify --from-audit` cross-checks both before
+  re-emitting.
+
+For operators who cannot tolerate even the audit-log-tail risk,
+`fsync_policy = "every_write"` removes the journal side of the
+window. The audit-log side is governed separately by
+`audit::BatchedAuditConfig` (Perf-N for a future PR).
+
+---
+
+## Cross-references
+
+- [audit-8 §3 throughput headlines](../audit/2026-05-20-load-perf-audit.md)
+  — the throughput table this PR derives from.
+- [`crates/octravpn-node/benches/settle_throughput.rs`] — repro the
+  numbers on your host: `cargo bench -p octravpn-node --bench
+  settle_throughput`.
+- [`docs/v2-threat-model.md` §3 P1-8 / P1-9] — the receipts-monotonic
+  invariant the journal exists to enforce.
+- [`docs/audit/2026-05-20-dr-drill-audit.md`] — the audit-9 H-RTO
+  drill that exercises `journal rebuild --from-audit`.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -188,6 +188,7 @@ Source: `config.rs::ControlCfg` at `:539-622`.
 | `events_token` | string | (none — endpoint 404s) | `:557` | Bearer for `GET /events` SSE. v2 hardening fix (P0-1). |
 | `metrics_token` | string | (none — endpoint 503s) | `:567` | Bearer for `GET /metrics`. Must set in production. Pick ≥32-byte random. |
 | `receipt_journal_path` | path | `./state/receipts.bin` | `:579` | P1-8/9 persistent seq journal. See [state-files.md](./state-files.md). |
+| `fsync_policy` | `"periodic"` \| `"every_write"` | `"periodic"` (Perf-1) | `config.rs::FsyncPolicyCfg` | Receipt-journal durability policy. `"periodic"` ⇒ `Periodic(1s)`, ~500 k receipts/s ceiling, ≤1 s loss window on hard crash (recoverable via `journal rebuild --from-audit`). `"every_write"` ⇒ `EveryWrite`, ~225 RPS/node ceiling, instantly durable per bump — pick for financial-invariant exit nodes. See [operators/performance.md](../operators/performance.md) and audit-8 §3. |
 | `admin_token` | string | (none — `POST /admin/preauth` 404s) | `:590` | Falls back to `OCTRAVPN_ADMIN_TOKEN`. |
 | `tailscale_wire_state_dir` | path | `./state/tailscale-wire` | `:599` | Noise long-term static + future wire state. Must survive restarts. |
 | `tailscale_tailnet_id` | string | `"octravpn-interop"` | `:606` | IP allocator key. Set per-deployment in production. |
@@ -359,6 +360,11 @@ audit_dir            = "/var/lib/octravpn/audit"
 metrics_token        = "${random ≥32 bytes}"
 admin_token          = "${random ≥32 bytes}"
 receipt_journal_path = "/var/lib/octravpn/receipts.bin"
+# Perf-1: receipt-journal fsync policy. "periodic" (default) trades
+# a ≤1 s loss window on hard crash for ~500 k receipts/s/node;
+# "every_write" is the financial-invariant override.
+# See docs/operators/performance.md.
+fsync_policy             = "periodic"
 tailscale_wire_state_dir = "/var/lib/octravpn/tailscale-wire"
 tailscale_tailnet_id     = "acme-prod"
 


### PR DESCRIPTION
## Summary

Flips the receipt-journal default from `EveryWrite` to `Periodic(1s)`. Lifts the per-node signed-receipt ceiling from ~225 RPS to ~500k RPS (audit-8 §3 table; `crates/octravpn-node/benches/settle_throughput.rs`) while bounding hard-crash loss to 1s of receipts — recoverable via the audit-log `journal rebuild --from-audit` CLI (audit-9 H-RTO).

* **Throughput delta.** Bench (`settle_throughput.rs:46-52`): `EveryWrite` ≈ 4.26 ms/bump (~225 RPS), `Periodic(1s)` ≈ 1.92 µs/bump (~500k RPS). 2000× ceiling lift on the same hardware.
* **Loss-window.** Up to one second of receipts at risk on a hard kernel/host crash. Process-only crashes (SIGKILL, panic) preserve every append — `O_APPEND write_all` is page-cache-backed, no user-space buffer.
* **Recovery story.** Audit log carries every `(session_id, seq)` the daemon committed before signing; `octravpn-node journal rebuild --from-audit <dir> --output <path>` reconstructs the floor map verbatim and HMAC-verifies the chain. Documented end-to-end in `docs/operators/performance.md`.
* **Override.** Financial-invariant operators flip back via `[control].fsync_policy = "every_write"`.

## Changes

* `octravpn_core::receipt_journal::FsyncPolicy::default()` ⇒ `Periodic(Duration::from_secs(1))` (new `DEFAULT_PERIODIC_FSYNC_INTERVAL` const; manual `Default` impl).
* `ControlCfg::fsync_policy: Option<FsyncPolicyCfg>` (snake_case TOML enum) + `ControlCfg::resolved_fsync_policy()` accessor.
* `build_hub` (`crates/octravpn-node/src/hub/boot.rs`) calls `journal.set_fsync_policy(cfg.control.resolved_fsync_policy())` post-open and logs the chosen policy.
* `bench_receipt_journal_bump` now pins `EveryWrite` explicitly so the durability-first baseline keeps measuring the per-fsync ceiling.
* Docs: new `docs/operators/performance.md` (launch note + recovery story); `docs/reference/config.md` adds the policy row + sample TOML; journal README + `set_fsync_policy` doc-comment updated.

No on-disk format change. No `bench-snapshots/core.json` shift (settle_throughput lives in `octravpn-node`, not core).

## Test plan

- [x] `cargo test -p octravpn-core fsync_policy::tests` — `default_is_periodic_one_second`, `every_write_variant_still_available` pass.
- [x] `cargo test -p octravpn-node config::tests` — `control_default_resolves_periodic_fsync`, `default_node_config_uses_periodic_fsync`, `control_every_write_override_parses`, `control_periodic_explicit_override_parses` pass.
- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace --no-fail-fast` — only failure is pre-existing `policy_e2e::policy_put_propagates_to_map_packet_filter` (CIDR expansion; commit `7136c3f` on main, unrelated to this PR).
- [ ] Operator-side: post-merge, run `cargo bench -p octravpn-node --bench settle_throughput` on a target host and confirm the analytic delta (1.92 µs/bump under `Periodic(1s)` vs 4.26 ms under `EveryWrite`).
- [ ] Operator-side: rehearse `journal rebuild --from-audit` against a torn-tail journal per `docs/operators/performance.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)