### PR TITLE
perf: hot-path cleanups (BoundedMap clock + keys, router install fast-path)

### DIFF
--- a/crates/octravpn-core/benches/core.rs
+++ b/crates/octravpn-core/benches/core.rs
@@ -260,6 +260,36 @@ fn bench_journal(c: &mut Criterion) {
     });
 }
 
+/// BoundedMap hot-path ops. Mirrors the node tunnel's
+/// `BoundedMap<[u8;32], AllowedClient>` (cap 4096): `keys()` (the
+/// handshake-admission path, which only needs pubkeys) vs `snapshot()`
+/// (clones every value too), plus `get()` (per-packet last-touch
+/// refresh off the monotonic clock).
+fn bench_bounded(c: &mut Criterion) {
+    use octravpn_core::bounded::BoundedMap;
+    use std::time::Duration;
+
+    // 96-byte value stands in for `AllowedClient`; 4096 == the allowlist
+    // cap, so this is the worst-case per-handshake enumeration size.
+    let map: BoundedMap<[u8; 32], [u8; 96]> = BoundedMap::new(4096, Duration::from_secs(300));
+    for i in 0..4096u32 {
+        let mut k = [0u8; 32];
+        k[..4].copy_from_slice(&i.to_le_bytes());
+        map.insert(k, [i as u8; 96]);
+    }
+    let mut probe = [0u8; 32];
+    probe[..4].copy_from_slice(&2048u32.to_le_bytes());
+
+    // E4: admission only needs keys (4096×32 B) — `snapshot` additionally
+    // clones 4096×96 B of values for nothing.
+    c.bench_function("bounded_keys_4096", |b| b.iter(|| black_box(map.keys())));
+    c.bench_function("bounded_snapshot_4096", |b| b.iter(|| black_box(map.snapshot())));
+    // E1: per-packet `get` refreshes last-touch off the monotonic clock.
+    c.bench_function("bounded_get", |b| {
+        b.iter(|| black_box(map.get(black_box(&probe))));
+    });
+}
+
 criterion_group!(
     benches,
     bench_receipt,
@@ -269,5 +299,6 @@ criterion_group!(
     bench_tx,
     bench_wallet_enc,
     bench_journal,
+    bench_bounded,
 );
 criterion_main!(benches);

--- a/crates/octravpn-core/benches/core.rs
+++ b/crates/octravpn-core/benches/core.rs
@@ -283,7 +283,9 @@ fn bench_bounded(c: &mut Criterion) {
     // E4: admission only needs keys (4096×32 B) — `snapshot` additionally
     // clones 4096×96 B of values for nothing.
     c.bench_function("bounded_keys_4096", |b| b.iter(|| black_box(map.keys())));
-    c.bench_function("bounded_snapshot_4096", |b| b.iter(|| black_box(map.snapshot())));
+    c.bench_function("bounded_snapshot_4096", |b| {
+        b.iter(|| black_box(map.snapshot()));
+    });
     // E1: per-packet `get` refreshes last-touch off the monotonic clock.
     c.bench_function("bounded_get", |b| {
         b.iter(|| black_box(map.get(black_box(&probe))));

--- a/crates/octravpn-core/src/bounded.rs
+++ b/crates/octravpn-core/src/bounded.rs
@@ -152,6 +152,15 @@ impl<K: Hash + Eq + Clone, V: Clone> BoundedMap<K, V> {
             .collect()
     }
 
+    /// Snapshot just the keys — clones the keys but **not** the values.
+    /// For callers that only need to enumerate keys (e.g. trial-matching
+    /// an incoming handshake against allowed pubkeys), this avoids
+    /// cloning every (potentially large) `V` the way [`Self::snapshot`]
+    /// does. The released lock lets the caller `.await` per key.
+    pub fn keys(&self) -> Vec<K> {
+        self.inner.lock().map.keys().cloned().collect()
+    }
+
     /// Number of entries inserted since `epoch`. Crude metric for tests
     /// and dashboards.
     pub fn elapsed_since_oldest(&self) -> Option<Duration> {
@@ -163,12 +172,17 @@ impl<K: Hash + Eq + Clone, V: Clone> BoundedMap<K, V> {
     }
 }
 
+/// Microseconds since a fixed process-start baseline, read off the
+/// **monotonic** clock. The value is only ever used for idle-TTL delta
+/// math (`now - last_touch`), so wall-clock is both unnecessary and
+/// wrong: a backward `SystemTime` jump (NTP step, `settimeofday`) could
+/// make a live entry look arbitrarily stale and evict it mid-session.
+/// `Instant` can't jump, and on macOS skips the pricier `gettimeofday`
+/// the wall-clock path took on every per-packet `get`/`modify`.
 fn mono_us() -> u64 {
-    use std::time::SystemTime;
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_micros() as u64)
-        .unwrap_or(0)
+    use std::sync::OnceLock;
+    static EPOCH: OnceLock<Instant> = OnceLock::new();
+    EPOCH.get_or_init(Instant::now).elapsed().as_micros() as u64
 }
 
 #[cfg(test)]

--- a/crates/octravpn-node/src/onion.rs
+++ b/crates/octravpn-node/src/onion.rs
@@ -65,7 +65,19 @@ impl OnionRouter {
     /// Install a route for a session. Idempotent: subsequent calls with
     /// the same `session_id` are a no-op (preserving accumulated byte
     /// counters), so the per-packet hot path may call it unconditionally.
+    ///
+    /// After the first packet of a session the entry already exists, so
+    /// this takes only a **read** lock in the steady state — the
+    /// per-packet common case no longer serializes on the write lock,
+    /// which matters under SO_REUSEPORT multi-queue where the write lock
+    /// would otherwise undo the per-shard parallelism. The write lock is
+    /// taken only when the entry is genuinely new; `entry().or_insert_with`
+    /// still handles the race where two first-packets for the same
+    /// session arrive concurrently.
     pub(crate) fn install(&self, session: SessionId, action: HopAction) {
+        if self.sessions.read().contains_key(&session) {
+            return;
+        }
         self.sessions
             .write()
             .entry(session)

--- a/crates/octravpn-node/src/tunnel/mod.rs
+++ b/crates/octravpn-node/src/tunnel/mod.rs
@@ -430,7 +430,11 @@ impl Server {
             self.shard_count,
         );
 
-        for (pk, _) in self.allowlist.snapshot() {
+        // Only the pubkey is needed to trial-decapsulate; `keys()` avoids
+        // cloning every `AllowedClient` value the way `snapshot()` did —
+        // this path is reachable by any unknown source address, so the
+        // per-packet allocation was a cheap UDP-flood amplifier.
+        for pk in self.allowlist.keys() {
             let mut tun = Tunn::new(
                 self.static_secret.clone(),
                 X25519Pub::from(pk),


### PR DESCRIPTION
Hot-path efficiency findings from the `/simplify` review, split into their own PR with a bench because they touch the datapath + durability surfaces (unlike the pure-cleanup work, which landed directly on main).

## Done (verified: clippy `-D warnings` clean, 719 tests pass core+node)

### E1 — monotonic `BoundedMap` clock (`octravpn-core/src/bounded.rs`)
`mono_us()` read wall-clock `SystemTime::now()` on every `get`/`modify`/`insert`/`sweep`, but the value only feeds idle-TTL delta math. Switched to a monotonic `Instant` baseline.
- **Correctness:** a backward NTP / `settimeofday` step can no longer make a live entry look stale and evict it mid-session.
- **Perf:** modest per-op saving (skips macOS's pricier wall-clock path); `Entry` already stored `inserted_at: Instant`, so this is consistent.

### E2 — read-lock `install` fast-path (`octravpn-node/src/onion.rs`)
`OnionRouter::install` took a **write** lock on the session map on *every* relay packet, though it's idempotent (after packet 1 the entry exists). Added a `contains_key` read-lock fast path; the write lock now fires only for a genuinely new session (the `entry().or_insert_with` slow path still handles the concurrent-first-packet race, so it stays correct + idempotent).
- Under SO_REUSEPORT multi-queue, the per-packet write lock otherwise serializes all queues and undoes the per-shard parallelism.

### E4 — `keys()`-not-`snapshot()` in handshake admission (`bounded.rs` + `tunnel/mod.rs`)
`try_admit_peer` trial-decapsulates an incoming handshake against the allowed pubkeys and **never uses the `AllowedClient` values**, yet `snapshot()` cloned all of them. Any unknown source address can reach this path, so the per-packet clone was a cheap UDP-flood amplifier. Added `BoundedMap::keys()` (clones keys only).

**Bench** (`cargo bench -p octravpn-core --bench core -- bounded`, full 4096-entry allowlist):

| op | time |
|----|------|
| `keys()` (new) | **9.5 µs** |
| `snapshot()` (old) | 28.4 µs |
| `get()` (per-packet, monotonic clock) | 89 ns |

→ ~3× less work + far less allocation per unknown-peer handshake.

## Proposed — needs focused review (NOT in this PR)

### E5 — per-request receipt-journal fsync
`journal.bump()` fsyncs synchronously on the async worker for every signed receipt (the hottest control-plane path). The audit log already solved this with a batched flusher (`audit/batched.rs`); the receipt journal has no equivalent.

**Deliberately not implemented here** because the durability contract is load-bearing for double-sign prevention (P1-8/9): a receipt must not be signed until its floor bump is durable. Any batching must preserve "ack only after durable", which is a real feature, not a mechanical change. Two options for a follow-up:
1. `spawn_blocking` the fsync off the runtime worker (safe, frees the worker, ~same latency).
2. Batched-fsync with a durability barrier (groups N bumps per fsync, acks the batch only after it lands) — bigger, mirrors `audit/batched.rs`.

Flagging for a maintainer call on which approach + a dedicated review of the durability invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)