### PR TITLE
fix(enroll): green up fmt + clippy on main after #59

### DIFF
--- a/crates/octravpn-core/src/enroll.rs
+++ b/crates/octravpn-core/src/enroll.rs
@@ -127,7 +127,11 @@ impl EnrollRequest {
     /// proves key possession only — the caller still has to check the
     /// nonce freshness and the wallet's authorization to join.
     pub fn verify_signature(&self) -> CoreResult<()> {
-        verify(&self.wallet_pubkey, &self.signing_payload(), &self.wallet_sig)
+        verify(
+            &self.wallet_pubkey,
+            &self.signing_payload(),
+            &self.wallet_sig,
+        )
     }
 }
 
@@ -221,7 +225,10 @@ mod tests {
         let req = signed_request(&kp, 3, "octCircleAAA", "deadbeef");
         // The admitted identity is exactly Address::from_pubkey — a device
         // cannot smuggle in a different wallet string.
-        assert_eq!(req.wallet_address(), Address::from_pubkey(&kp.public.0).display());
+        assert_eq!(
+            req.wallet_address(),
+            Address::from_pubkey(&kp.public.0).display()
+        );
         assert!(req.wallet_address().starts_with("oct"));
     }
 
@@ -239,10 +246,22 @@ mod tests {
         let kp = KeyPair::generate();
         let base = enroll_signing_payload(3, "octC", &kp.public, &[7u8; 32], "n1");
         // Each field change must change the payload (no collisions).
-        assert_ne!(base, enroll_signing_payload(4, "octC", &kp.public, &[7u8; 32], "n1"));
-        assert_ne!(base, enroll_signing_payload(3, "octD", &kp.public, &[7u8; 32], "n1"));
-        assert_ne!(base, enroll_signing_payload(3, "octC", &kp.public, &[8u8; 32], "n1"));
-        assert_ne!(base, enroll_signing_payload(3, "octC", &kp.public, &[7u8; 32], "n2"));
+        assert_ne!(
+            base,
+            enroll_signing_payload(4, "octC", &kp.public, &[7u8; 32], "n1")
+        );
+        assert_ne!(
+            base,
+            enroll_signing_payload(3, "octD", &kp.public, &[7u8; 32], "n1")
+        );
+        assert_ne!(
+            base,
+            enroll_signing_payload(3, "octC", &kp.public, &[8u8; 32], "n1")
+        );
+        assert_ne!(
+            base,
+            enroll_signing_payload(3, "octC", &kp.public, &[7u8; 32], "n2")
+        );
         // Length-prefixing prevents the classic concat ambiguity:
         // ("oct","Cn1") must not collide with ("octC","n1").
         let a = enroll_signing_payload(3, "oct", &kp.public, &[7u8; 32], "Cn1");

--- a/crates/octravpn-node/src/circle_update.rs
+++ b/crates/octravpn-node/src/circle_update.rs
@@ -493,7 +493,13 @@ pub(crate) async fn read_sealed_asset(
     let Ok(sealed) = std::str::from_utf8(&bytes) else {
         return Ok(SealedRead::Corrupt);
     };
-    match decrypt_sealed_bytes(circle_id, key_id, creds.passphrase(), sealed.trim(), expected_hash) {
+    match decrypt_sealed_bytes(
+        circle_id,
+        key_id,
+        creds.passphrase(),
+        sealed.trim(),
+        expected_hash,
+    ) {
         Ok(plain) => Ok(SealedRead::Valid(plain)),
         Err(_) => Ok(SealedRead::Corrupt),
     }
@@ -771,9 +777,10 @@ pub(crate) async fn list_orphaned_blobs(
     for (path, _field, expected_hex) in probes {
         // A blob present on chain that doesn't decrypt/verify against its
         // anchor is exactly a `Corrupt` read; absent or valid is fine.
-        if let SealedRead::Corrupt =
-            read_sealed_asset(ctx, circle_id, path, "default", creds, expected_hex).await?
-        {
+        if matches!(
+            read_sealed_asset(ctx, circle_id, path, "default", creds, expected_hex).await?,
+            SealedRead::Corrupt
+        ) {
             orphans.push((*path).to_string());
         }
     }
@@ -782,10 +789,11 @@ pub(crate) async fn list_orphaned_blobs(
     const ATTESTATION_PATH: &str = "/attestation.json";
     match current.attestation_hash.as_deref() {
         Some(expected) => {
-            if let SealedRead::Corrupt =
+            if matches!(
                 read_sealed_asset(ctx, circle_id, ATTESTATION_PATH, "default", creds, expected)
-                    .await?
-            {
+                    .await?,
+                SealedRead::Corrupt
+            ) {
                 orphans.push(ATTESTATION_PATH.to_string());
             }
         }

--- a/crates/octravpn-node/src/control/enroll.rs
+++ b/crates/octravpn-node/src/control/enroll.rs
@@ -119,7 +119,11 @@ pub(crate) struct EnrollService {
 
 impl EnrollService {
     #[allow(dead_code)] // wired by the Hub when an operator hosts a tailnet
-    pub(crate) fn new(tailnet_id: u64, circle: impl Into<String>, store: Arc<dyn EnrollStore>) -> Self {
+    pub(crate) fn new(
+        tailnet_id: u64,
+        circle: impl Into<String>,
+        store: Arc<dyn EnrollStore>,
+    ) -> Self {
         Self {
             tailnet_id,
             circle: circle.into(),
@@ -164,7 +168,8 @@ impl EnrollService {
     ) -> Result<EnrollResponse, EnrollError> {
         // 1. Possession of the wallet key (binds wallet ↔ wg key ↔
         //    tailnet ↔ circle ↔ nonce).
-        req.verify_signature().map_err(|_| EnrollError::BadSignature)?;
+        req.verify_signature()
+            .map_err(|_| EnrollError::BadSignature)?;
 
         // 2. This operator actually serves the named tailnet/circle.
         if req.tailnet_id != self.tailnet_id {
@@ -182,7 +187,10 @@ impl EnrollService {
 
         // 3. Consume the single-use nonce (replay guard). `remove`
         //    makes it one-shot; the TTL map also drops stale entries.
-        let challenge = self.challenges.remove(&req.nonce).ok_or(EnrollError::StaleNonce)?;
+        let challenge = self
+            .challenges
+            .remove(&req.nonce)
+            .ok_or(EnrollError::StaleNonce)?;
         if now > challenge.expires_at {
             return Err(EnrollError::StaleNonce);
         }
@@ -222,10 +230,8 @@ impl EnrollService {
 
         // 8. Build the response: the device's deterministic IP + every
         //    *other* member as a reachable peer.
-        let allocator = TailnetIpAllocator::with_salt(
-            self.tailnet_id.to_string(),
-            salt_u32(&members.ip_salt),
-        );
+        let allocator =
+            TailnetIpAllocator::with_salt(self.tailnet_id.to_string(), salt_u32(&members.ip_salt));
         let assigned_ip = allocator.allocate(&wallet).to_string();
         let peers = members
             .members
@@ -306,7 +312,9 @@ impl EnrollStore for InMemoryEnrollStore {
             .unwrap()
             .get(&tailnet_id)
             .cloned()
-            .unwrap_or_else(|| TailnetMembers::new_v1(tailnet_id, self.ip_salt.clone(), vec![], 0, 0));
+            .unwrap_or_else(|| {
+                TailnetMembers::new_v1(tailnet_id, self.ip_salt.clone(), vec![], 0, 0)
+            });
         Ok(EnrollState {
             allowlist: AllowList { wallets },
             members,
@@ -318,7 +326,10 @@ impl EnrollStore for InMemoryEnrollStore {
         tailnet_id: u64,
         members: &TailnetMembers,
     ) -> Result<u64, EnrollError> {
-        self.members.lock().unwrap().insert(tailnet_id, members.clone());
+        self.members
+            .lock()
+            .unwrap()
+            .insert(tailnet_id, members.clone());
         let mut v = self.version.lock().unwrap();
         let next = v.get(&tailnet_id).copied().unwrap_or(0) + 1;
         v.insert(tailnet_id, next);
@@ -334,7 +345,11 @@ mod tests {
 
     const SALT: &str = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
 
-    fn service_with_allow(tailnet_id: u64, circle: &str, wallet: &str) -> (EnrollService, Arc<InMemoryEnrollStore>) {
+    fn service_with_allow(
+        tailnet_id: u64,
+        circle: &str,
+        wallet: &str,
+    ) -> (EnrollService, Arc<InMemoryEnrollStore>) {
         let store = Arc::new(InMemoryEnrollStore::new(SALT));
         store.allow(tailnet_id, wallet);
         let svc = EnrollService::new(tailnet_id, circle, store.clone());
@@ -364,7 +379,9 @@ mod tests {
     #[tokio::test]
     async fn happy_path_admits_and_returns_ip() {
         let kp = KeyPair::generate();
-        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0).display().to_string();
+        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0)
+            .display()
+            .to_string();
         let (svc, store) = service_with_allow(7, "octCircle", &wallet);
 
         let ch = svc.issue_challenge(&wallet, 1000);
@@ -383,7 +400,9 @@ mod tests {
     #[tokio::test]
     async fn unauthorized_wallet_is_rejected() {
         let kp = KeyPair::generate();
-        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0).display().to_string();
+        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0)
+            .display()
+            .to_string();
         // Service whose allowlist does NOT contain this wallet.
         let store = Arc::new(InMemoryEnrollStore::new(SALT));
         let svc = EnrollService::new(7, "octCircle", store.clone());
@@ -393,7 +412,13 @@ mod tests {
         let err = svc.enroll(&req, 1001).await.unwrap_err();
         assert!(matches!(err, EnrollError::NotAuthorized(_)));
         assert_eq!(
-            store.load_enroll_state(7).await.unwrap().members.members.len(),
+            store
+                .load_enroll_state(7)
+                .await
+                .unwrap()
+                .members
+                .members
+                .len(),
             0
         );
     }
@@ -401,7 +426,9 @@ mod tests {
     #[tokio::test]
     async fn nonce_is_single_use() {
         let kp = KeyPair::generate();
-        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0).display().to_string();
+        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0)
+            .display()
+            .to_string();
         let (svc, _store) = service_with_allow(7, "octCircle", &wallet);
 
         let ch = svc.issue_challenge(&wallet, 1000);
@@ -415,7 +442,9 @@ mod tests {
     #[tokio::test]
     async fn forged_request_without_challenge_is_rejected() {
         let kp = KeyPair::generate();
-        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0).display().to_string();
+        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0)
+            .display()
+            .to_string();
         let (svc, _store) = service_with_allow(7, "octCircle", &wallet);
         // A validly-signed request, but for a nonce the service never issued.
         let req = signed_request(&kp, 7, "octCircle", "never-issued");
@@ -426,7 +455,9 @@ mod tests {
     #[tokio::test]
     async fn wrong_tailnet_is_rejected() {
         let kp = KeyPair::generate();
-        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0).display().to_string();
+        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0)
+            .display()
+            .to_string();
         let (svc, _store) = service_with_allow(7, "octCircle", &wallet);
         let ch = svc.issue_challenge(&wallet, 1000);
         // Sign + send for tailnet 9 against a service serving tailnet 7.
@@ -438,7 +469,9 @@ mod tests {
     #[tokio::test]
     async fn re_enroll_replaces_device_key_not_duplicates() {
         let kp = KeyPair::generate();
-        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0).display().to_string();
+        let wallet = octravpn_core::Address::from_pubkey(&kp.public.0)
+            .display()
+            .to_string();
         let (svc, store) = service_with_allow(7, "octCircle", &wallet);
 
         let ch1 = svc.issue_challenge(&wallet, 1000);
@@ -454,7 +487,13 @@ mod tests {
         // Same wallet, two enrollments → one member, version bumped.
         assert_eq!(v2.members_version, 2);
         assert_eq!(
-            store.load_enroll_state(7).await.unwrap().members.members.len(),
+            store
+                .load_enroll_state(7)
+                .await
+                .unwrap()
+                .members
+                .members
+                .len(),
             1
         );
     }

--- a/crates/octravpn-node/src/control/enroll_circle.rs
+++ b/crates/octravpn-node/src/control/enroll_circle.rs
@@ -39,7 +39,9 @@ use octravpn_core::{circle::PaddingClass, v3_members::TailnetMembers, v3_state_r
 
 use super::enroll::{AllowList, EnrollError, EnrollState, EnrollStore};
 use crate::chain_v3::ChainCtxV3;
-use crate::circle_update::{self, AnchorOverrides, BlobUpdate, SealedAssetCreds, SealedRead, UpdateBundle};
+use crate::circle_update::{
+    self, AnchorOverrides, BlobUpdate, SealedAssetCreds, SealedRead, UpdateBundle,
+};
 
 /// Sealed, anchored asset holding the enrolled member set (`TailnetMembers`).
 const MEMBERS_PATH: &str = "/auth/members.json";

--- a/crates/octravpn-node/src/control/handlers/enroll.rs
+++ b/crates/octravpn-node/src/control/handlers/enroll.rs
@@ -84,9 +84,9 @@ fn not_enabled() -> axum::response::Response {
 /// silently defaulting to 500.
 fn status_for(e: &EnrollError) -> (StatusCode, String) {
     match e {
-        EnrollError::BadSignature
-        | EnrollError::StaleNonce
-        | EnrollError::NonceWalletMismatch => (StatusCode::UNAUTHORIZED, e.to_string()),
+        EnrollError::BadSignature | EnrollError::StaleNonce | EnrollError::NonceWalletMismatch => {
+            (StatusCode::UNAUTHORIZED, e.to_string())
+        }
         EnrollError::WrongTailnet { .. }
         | EnrollError::WrongCircle { .. }
         | EnrollError::Members(_) => (StatusCode::BAD_REQUEST, e.to_string()),


### PR DESCRIPTION
PR #59 (wallet-native enrollment) merged without the `--all-targets` lint gates, leaving `main` red on `cargo +nightly fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings`.

**No behavior change** — lint-only:
- rustfmt drift across the new `octravpn-core::enroll`, `control::enroll`, `control::enroll_circle`, `handlers::enroll`, and `circle_update` files (formatted with nightly to match CI).
- clippy `match_like_matches_macro`: the two `if let SealedRead::Corrupt = read_sealed_asset(..).await?` orphan probes in `list_orphaned_blobs` become `matches!(.., SealedRead::Corrupt)`.

Verified locally: `cargo +nightly fmt --all -- --check` and `cargo clippy --workspace --all-targets -- -D warnings` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)