### PR TITLE
chore(toolchain): pin Rust 1.96.0 (was 1.88.0) + clear lint churn

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -21,7 +21,7 @@ inputs:
       Default matches the workspace's `rust-toolchain.toml` so CI
       and local builds agree on rustfmt + clippy lint sets.
     required: false
-    default: "1.88.0"
+    default: "1.96.0"
   components:
     description: "Comma-separated rustup components (clippy, rustfmt, ...)"
     required: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["OctraVPN contributors"]
-rust-version = "1.75"
+# Real floor: the code uses the generic `std::num::NonZero` API (stable
+# 1.79). The pinned toolchain (rust-toolchain.toml) is newer; this only
+# declares the minimum the source actually compiles on.
+rust-version = "1.79"
 
 [workspace.dependencies]
 anyhow      = "1"

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ cd octra && cargo build --workspace
 ## Quickstart — local
 
 Prereqs: **Rust** via [rustup](https://rustup.rs) (the repo's
-`rust-toolchain.toml` auto-selects 1.88.0 — no manual version pick) and the
+`rust-toolchain.toml` auto-selects 1.96.0 — no manual version pick) and the
 **two sibling repos** cloned side-by-side, per
 [Sibling repos](#sibling-repos-path-deps) above.
 

--- a/crates/octravpn-analytics/src/http.rs
+++ b/crates/octravpn-analytics/src/http.rs
@@ -261,8 +261,7 @@ async fn health(State(s): State<HttpState>) -> Response {
 fn now_unix_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/octravpn-analytics/src/indexer.rs
+++ b/crates/octravpn-analytics/src/indexer.rs
@@ -324,8 +324,7 @@ impl Indexer {
 fn now_unix_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/octravpn-client/src/commands/bugreport.rs
+++ b/crates/octravpn-client/src/commands/bugreport.rs
@@ -30,8 +30,7 @@ use crate::config::ClientConfig;
 pub(crate) fn run(config_path: &str, out_path: Option<&str>) -> Result<()> {
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
 
     let default_name = format!("./octravpn-bugreport-{ts}.tar.gz");
     let out = out_path.unwrap_or(&default_name);

--- a/crates/octravpn-client/src/portal/mod.rs
+++ b/crates/octravpn-client/src/portal/mod.rs
@@ -57,7 +57,7 @@ pub(crate) async fn run_portal(chain: PortalChain, bind: SocketAddr) -> Result<(
 pub(crate) async fn is_running(addr: SocketAddr) -> bool {
     let url = format!("http://{addr}/healthz");
     let Ok(client) = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_millis(1_000))
+        .timeout(std::time::Duration::from_secs(1))
         .build()
     else {
         return false;

--- a/crates/octravpn-client/src/portal/routes.rs
+++ b/crates/octravpn-client/src/portal/routes.rs
@@ -174,10 +174,7 @@ impl PortalState {
     }
 
     pub(crate) fn is_allowed(&self, circle_id: &str) -> bool {
-        self.allow_set
-            .lock()
-            .map(|s| s.contains(circle_id))
-            .unwrap_or(false)
+        self.allow_set.lock().is_ok_and(|s| s.contains(circle_id))
     }
 
     pub(crate) fn allow(&self, circle_id: &str) {
@@ -403,7 +400,7 @@ async fn raw_asset(State(state): State<PortalState>, Query(q): Query<RawQuery>) 
         None => false,
     };
     if !approved_by_token && !state.is_allowed(&parsed.circle_id) {
-        let approve_url = format!("/confirm?u={}&accept=cli", urlencode_query_value(&q.u),);
+        let approve_url = format!("/confirm?u={}&accept=cli", urlencode_query_value(&q.u));
         return (
             StatusCode::PRECONDITION_FAILED,
             Json(json!({
@@ -1369,7 +1366,7 @@ mod tests {
         let resp = app
             .oneshot(
                 Request::builder()
-                    .uri(format!("/raw?u={}", urlenc("oct://circSEAL/policy.json"),))
+                    .uri(format!("/raw?u={}", urlenc("oct://circSEAL/policy.json")))
                     .body(Body::empty())
                     .unwrap(),
             )

--- a/crates/octravpn-client/tests/bugreport.rs
+++ b/crates/octravpn-client/tests/bugreport.rs
@@ -151,11 +151,9 @@ fn bugreport_redacts_secret_contents() {
     // The wallet path string should appear *somewhere* in the bundle (so
     // the recipient knows where the wallet lives on the user's box).
     let wallet_path_str = wallet.to_string_lossy().into_owned();
-    let mentions_path = entries.iter().any(|(_, bytes)| {
-        std::str::from_utf8(bytes)
-            .map(|s| s.contains(&wallet_path_str))
-            .unwrap_or(false)
-    });
+    let mentions_path = entries
+        .iter()
+        .any(|(_, bytes)| std::str::from_utf8(bytes).is_ok_and(|s| s.contains(&wallet_path_str)));
     assert!(
         mentions_path,
         "no archive entry mentions the wallet path {wallet_path_str}"

--- a/crates/octravpn-client/tests/v3_client_integration.rs
+++ b/crates/octravpn-client/tests/v3_client_integration.rs
@@ -453,7 +453,7 @@ async fn cold_open_session_then_settle_confirm() {
         .as_str()
         .expect("get_circle_state_root returns a hex string")
         .to_string();
-    assert_eq!(anchor_str.len(), 64, "anchor must be a 64-char hex SHA-256",);
+    assert_eq!(anchor_str.len(), 64, "anchor must be a 64-char hex SHA-256");
 
     // ---- step 1b: validate the operator's sealed policy against
     //               the on-chain anchor. This is the critical step

--- a/crates/octravpn-core/src/spki_verifier.rs
+++ b/crates/octravpn-core/src/spki_verifier.rs
@@ -665,7 +665,7 @@ mod tests {
             ),
             "expected ApplicationVerificationFailure, got {err:?}"
         );
-        assert_eq!(inner.count(), 0, "inner must NOT run on a mismatched SPKI",);
+        assert_eq!(inner.count(), 0, "inner must NOT run on a mismatched SPKI");
     }
 
     /// Test 3 — rotation grace: multiple pins are supported, any one

--- a/crates/octravpn-core/src/v3_members.rs
+++ b/crates/octravpn-core/src/v3_members.rs
@@ -391,7 +391,7 @@ fn check_ip_salt(value: &str) -> Result<(), V3MembersError> {
     // so verifiers don't have to case-fold).
     if !value
         .bytes()
-        .all(|b| (b.is_ascii_digit() || (b'a'..=b'f').contains(&b)))
+        .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
     {
         return Err(V3MembersError::BadIpSaltEncoding);
     }

--- a/crates/octravpn-mesh/src/headscale_bridge/preauth.rs
+++ b/crates/octravpn-mesh/src/headscale_bridge/preauth.rs
@@ -353,8 +353,7 @@ pub enum RedeemError {
 pub(super) fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
 }
 
 #[cfg(test)]

--- a/crates/octravpn-mesh/src/knock.rs
+++ b/crates/octravpn-mesh/src/knock.rs
@@ -79,8 +79,7 @@ pub fn knock_at_window(psk: &[u8; 32], window: u64) -> String {
 fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
 }
 
 /// Decode a base64-encoded PSK string into a 32-byte secret.

--- a/crates/octravpn-mesh/src/subnet.rs
+++ b/crates/octravpn-mesh/src/subnet.rs
@@ -112,7 +112,8 @@ impl SubnetRouter {
             .filter(|a| a.cidr.contains(ip))
             .cloned()
             .collect();
-        hits.sort_by(|a, b| b.cidr.prefix_len.cmp(&a.cidr.prefix_len));
+        // Longest-prefix-match first: descending prefix_len.
+        hits.sort_by_key(|a| std::cmp::Reverse(a.cidr.prefix_len));
         hits
     }
 

--- a/crates/octravpn-node/benches/audit_boot_replay.rs
+++ b/crates/octravpn-node/benches/audit_boot_replay.rs
@@ -115,7 +115,7 @@ fn main() {
     let t0 = Instant::now();
     build_synthetic_log(&path, &key, N_LINES);
     let build_ms = t0.elapsed().as_millis();
-    let file_bytes = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    let file_bytes = std::fs::metadata(&path).map_or(0, |m| m.len());
     println!("  built {N_LINES} lines = {file_bytes} bytes in {build_ms} ms");
 
     // Warm the disk cache identically for both paths.

--- a/crates/octravpn-node/benches/settle_throughput.rs
+++ b/crates/octravpn-node/benches/settle_throughput.rs
@@ -131,12 +131,10 @@ fn bench_receipt_journal_bump(c: &mut Criterion) {
                 for i in 1..n_sessions {
                     let _ = j.bump(&session_id_from(i as u64), 1);
                 }
-                let mut next_seq = 2u64;
                 let start = Instant::now();
-                for _ in 0..iters {
+                for next_seq in 2..2 + iters {
                     j.bump(black_box(&primary), black_box(next_seq))
                         .expect("bump");
-                    next_seq += 1;
                 }
                 start.elapsed()
             });
@@ -167,12 +165,10 @@ fn bench_receipt_journal_bump_periodic(c: &mut Criterion) {
                 for i in 1..n_sessions {
                     let _ = j.bump(&session_id_from(i as u64), 1);
                 }
-                let mut next_seq = 2u64;
                 let start = Instant::now();
-                for _ in 0..iters {
+                for next_seq in 2..2 + iters {
                     j.bump(black_box(&primary), black_box(next_seq))
                         .expect("bump");
-                    next_seq += 1;
                 }
                 start.elapsed()
             });

--- a/crates/octravpn-node/src/audit/log.rs
+++ b/crates/octravpn-node/src/audit/log.rs
@@ -237,7 +237,7 @@ fn open_or_rotate(inner: &mut Inner, date: &str, next_line_len: u64) -> Result<b
     inner.current_file_id = basename;
     // Size is recovered from disk if we're continuing an existing
     // file, else zero on a fresh file.
-    let on_disk = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+    let on_disk = std::fs::metadata(&path).map_or(0, |m| m.len());
     inner.current_file_size = on_disk;
 
     // Enforce ring buffer AFTER opening the new file so we never
@@ -289,7 +289,7 @@ fn recover_chain_for_date(
         .and_then(|s| s.to_str())
         .map(String::from)
         .unwrap_or_default();
-    let latest_size = std::fs::metadata(&latest).map(|m| m.len()).unwrap_or(0);
+    let latest_size = std::fs::metadata(&latest).map_or(0, |m| m.len());
 
     // Fast path: tip file points at the latest file with a valid MAC.
     if let Some(tip) = ChainTip::load(dir) {
@@ -521,12 +521,10 @@ mod tests {
         let count = std::fs::read_dir(dir.path())
             .unwrap()
             .filter(|e| {
-                e.as_ref()
-                    .map(|e| {
-                        let n = e.file_name().to_string_lossy().to_string();
-                        n.starts_with("audit-") && is_jsonl_name(&n)
-                    })
-                    .unwrap_or(false)
+                e.as_ref().is_ok_and(|e| {
+                    let n = e.file_name().to_string_lossy().to_string();
+                    n.starts_with("audit-") && is_jsonl_name(&n)
+                })
             })
             .count();
         assert_eq!(count, 2, "expected two daily audit files");

--- a/crates/octravpn-node/src/chain_v2.rs
+++ b/crates/octravpn-node/src/chain_v2.rs
@@ -498,8 +498,7 @@ fn current_timestamp_f64() -> f64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(0.0)
+        .map_or(0.0, |d| d.as_secs_f64())
 }
 
 impl PolicyBundle {

--- a/crates/octravpn-node/src/circle_update.rs
+++ b/crates/octravpn-node/src/circle_update.rs
@@ -557,8 +557,7 @@ fn current_timestamp_f64() -> f64 {
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs_f64())
-        .unwrap_or(0.0)
+        .map_or(0.0, |d| d.as_secs_f64())
 }
 
 /// Apply an [`UpdateBundle`] atomically (blobs-first-anchor-second).

--- a/crates/octravpn-node/src/cli/mesh.rs
+++ b/crates/octravpn-node/src/cli/mesh.rs
@@ -633,8 +633,7 @@ fn trim_body(s: &str, max: usize) -> String {
 /// §"PSK-gated control plane" for the operator playbook.
 fn load_knock_cfg_from_env() -> octravpn_mesh::tailscale_wire::KnockConfig {
     let enabled = std::env::var("OCTRAVPN_KNOCK_ENABLED")
-        .map(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"))
-        .unwrap_or(false);
+        .is_ok_and(|v| !v.is_empty() && v != "0" && !v.eq_ignore_ascii_case("false"));
     if !enabled {
         return octravpn_mesh::tailscale_wire::KnockConfig::disabled();
     }

--- a/crates/octravpn-node/src/config.rs
+++ b/crates/octravpn-node/src/config.rs
@@ -535,21 +535,16 @@ const fn default_audit_max_file_count() -> usize {
 /// receipt_pubkey)`. v3 has no HFHE — settlement uses a sha256 hash
 /// chain of `(prev_head || sha256(settle_blinding))`. See
 /// `docs/v3-state-root-schema.md` and `crates/octravpn-core/src/v3_state_root.rs`.
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ProtocolVersion {
     #[serde(rename = "v1.1", alias = "v1")]
+    #[default]
     V1_1,
     #[serde(rename = "v2")]
     V2,
     #[serde(rename = "v3")]
     V3,
-}
-
-impl Default for ProtocolVersion {
-    fn default() -> Self {
-        Self::V1_1
-    }
 }
 
 #[derive(Deserialize, Clone)]

--- a/crates/octravpn-node/src/mesh_ops.rs
+++ b/crates/octravpn-node/src/mesh_ops.rs
@@ -196,9 +196,7 @@ fn allow_invalid_certs_for_remote_with_env(remote: &str, env_override: Option<&s
     if host.eq_ignore_ascii_case("localhost") {
         return true;
     }
-    host.parse::<IpAddr>()
-        .map(|ip| ip.is_loopback())
-        .unwrap_or(false)
+    host.parse::<IpAddr>().is_ok_and(|ip| ip.is_loopback())
 }
 
 fn url_join(remote: &str, path: &str) -> String {
@@ -400,6 +398,7 @@ fn trim(s: &str, max: usize) -> String {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Serialize, Deserialize)]
+#[allow(dead_code)] // reserved test-fixture scaffolding (see comment above)
 pub(crate) struct MachineFixture {
     pub id: String,
     pub hostname: String,

--- a/crates/octravpn-node/src/pvac.rs
+++ b/crates/octravpn-node/src/pvac.rs
@@ -937,9 +937,8 @@ mod tests {
             ..PvacConfig::default()
         };
         let res = PvacClient::spawn(cfg).await;
-        let err = match res {
-            Ok(_) => panic!("expected Spawn error, got Ok(client)"),
-            Err(e) => e,
+        let Err(err) = res else {
+            panic!("expected Spawn error, got Ok(client)");
         };
         match err {
             PvacError::Spawn { path, .. } => {

--- a/crates/octravpn-node/src/tunnel/mod.rs
+++ b/crates/octravpn-node/src/tunnel/mod.rs
@@ -67,8 +67,7 @@ pub(crate) const MAX_SHARDS: usize = 8;
 /// is the modern equivalent.
 fn default_shard_count() -> usize {
     std::thread::available_parallelism()
-        .map(std::num::NonZero::get)
-        .unwrap_or(1)
+        .map_or(1, std::num::NonZero::get)
         .clamp(1, MAX_SHARDS)
 }
 

--- a/crates/octravpn-node/src/v3_cli.rs
+++ b/crates/octravpn-node/src/v3_cli.rs
@@ -911,9 +911,8 @@ region = "test"
 listen = "0.0.0.0:51821"
 "#;
         let cfg: crate::config::NodeConfig = ::toml::from_str(toml).unwrap();
-        let err = match build_chain_ctx(&cfg) {
-            Ok(_) => panic!("expected wallet-missing error"),
-            Err(e) => e,
+        let Err(err) = build_chain_ctx(&cfg) else {
+            panic!("expected wallet-missing error");
         };
         assert!(format!("{err:#}").to_lowercase().contains("wallet"));
     }

--- a/crates/octravpn-obfs4/src/iat.rs
+++ b/crates/octravpn-obfs4/src/iat.rs
@@ -30,10 +30,11 @@ use std::time::Duration;
 use rand::{Rng, RngCore};
 
 /// Selects the IAT delay distribution.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum IatMode {
     /// No injected delay. Cheapest; relies on length randomisation
     /// alone for traffic-shape obfuscation. Default.
+    #[default]
     Off,
     /// Uniform 0..25 ms. Cheap, defeats simple "WG sends bursts every
     /// N ms" heuristics.
@@ -42,12 +43,6 @@ pub enum IatMode {
     /// latency. Recommended only on overlay traffic that already
     /// tolerates RTT (e.g. cross-region tunnels).
     Pareto,
-}
-
-impl Default for IatMode {
-    fn default() -> Self {
-        Self::Off
-    }
 }
 
 impl IatMode {

--- a/crates/octravpn-tun/src/derp/front.rs
+++ b/crates/octravpn-tun/src/derp/front.rs
@@ -229,8 +229,7 @@ impl FrontClient {
     pub fn plan(&self, method: &str, path: &str, body: &[u8]) -> Result<DialPlan> {
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         self.plan_at(method, path, body, ts)
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,12 @@
+# Pinned to an exact stable patch (not `stable`) on purpose:
+#  - rustfmt + clippy lint sets stay identical in CI and locally, so the
+#    `fmt --check` / `clippy -D warnings` gates don't drift when a new
+#    Rust ships new lints/formatting (see .github/actions/setup-rust).
+#  - reproducible builds: the rustc commit hash is embedded in std panic
+#    strings, so an exact patch pin yields byte-identical binaries
+#    (audit R3, docs/audit/2026-05-20-reproducible-builds-audit.md).
+# Bump deliberately — it's a lint-churn event — and keep this in sync with
+# the setup-rust action default. MSRV is separate (Cargo.toml rust-version).
 [toolchain]
-channel = "1.88.0"
+channel = "1.96.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Why
The `1.88.0` pin broke the nightly **`cargo tarpaulin`** gate: a transitive dep of cargo-tarpaulin (`cargo-platform 0.3.3`) raised its MSRV to rustc 1.91, so the coverage tool itself no longer builds under the pin.

## What
- Bump the pinned channel `1.88.0 → 1.96.0` (current stable), keeping `setup-rust` action default + README in sync.
- Clear the clippy lint churn the newer lint set surfaces — all **mechanical, behavior-preserving**: `map_or`, `let…else`, ranged loops, derived `Default`, `sort_by_key(Reverse)`, parens/commas.
- **Document why the toolchain is pinned** in `rust-toolchain.toml` (rustfmt+clippy determinism + reproducible builds, audit R3) so it's not a mystery.
- Correct workspace MSRV `1.75 → 1.79`: the code uses the generic `std::num::NonZero` API (stable 1.79); `1.75` was already false. Pin and MSRV are separate knobs.

## Verified under 1.96.0
- `cargo +nightly fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- octravpn-core **321** + octravpn-node **412** unit tests pass

The historical audit doc (2026-05-20) keeps its `1.88.0` references as a point-in-time record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)