### PR TITLE
fix(fuzz): repair two false-positive fuzz targets (build break + bad assert)

### DIFF
--- a/fuzz/fuzz_targets/fuzz_preauth_redeem.rs
+++ b/fuzz/fuzz_targets/fuzz_preauth_redeem.rs
@@ -22,7 +22,7 @@
 //!     invariant; an adversary that retries on network errors must
 //!     get exactly one success across all attempts)
 use libfuzzer_sys::fuzz_target;
-use octravpn_mesh::{PreauthMinter, RedeemError};
+use octravpn_mesh::PreauthMinter;
 use std::time::Duration;
 
 fuzz_target!(|data: &[u8]| {
@@ -79,10 +79,12 @@ fuzz_target!(|data: &[u8]| {
                             );
                         }
                     }
-                    Err(RedeemError::Unknown) | Err(RedeemError::Expired) => {
-                        // Both are fine outcomes — eviction (cap),
-                        // expiry (1ms TTL), or already-redeemed
-                        // single-use.
+                    Err(_) => {
+                        // Any rejection is a fine outcome — eviction
+                        // (cap), expiry (1ms TTL), or already-redeemed
+                        // single-use. `RedeemError` is #[non_exhaustive],
+                        // so a wildcard is required (and any future
+                        // variant is likewise a non-panic rejection here).
                     }
                 }
             }

--- a/fuzz/fuzz_targets/fuzz_validator_health_oracle.rs
+++ b/fuzz/fuzz_targets/fuzz_validator_health_oracle.rs
@@ -28,6 +28,14 @@
 //! oracle — the oracle's role is purely set-membership lookup. This
 //! target catches the off-chain panic surface; chain-side bounded-FP
 //! analysis happens in `program/tests/` proofs.
+//!
+//! Invariant note: this target asserts only that the decode + lookup
+//! path is *total* (never panics) for any input. It deliberately does
+//! NOT assert anything about address *content* — an earlier version
+//! asserted addresses held no NUL byte, but a JSON string may legally
+//! encode one, so that assert flagged valid input as a crash (a
+//! harness false positive, not a code defect). A pathological address
+//! is stored opaquely and simply never matches a real validator.
 use libfuzzer_sys::fuzz_target;
 use serde_json::Value;
 use std::collections::HashSet;
@@ -51,13 +59,13 @@ fuzz_target!(|data: &[u8]| {
             .filter_map(|x| x.as_str().map(String::from))
             .collect();
 
-        // 3. Membership-check invariant: every address in the set is
-        //    well-defined UTF-8 (already true by construction from
-        //    `as_str`), and the lookup function is total.
+        // 3. Membership-check invariant: the lookup is total for every
+        //    decoded address. Addresses are well-defined UTF-8 by
+        //    construction (`as_str`); any byte content — NUL and other
+        //    control chars included — must look up without panicking,
+        //    not be rejected here (see the invariant note above).
         for s in &set {
             let _ = set.contains(s);
-            // Decode-shaped string must be safe to use as map key.
-            assert!(!s.contains('\0'), "validator addr contains NUL: {s:?}");
         }
 
         // 4. Edge case the brief calls out: "wildly out-of-band
@@ -76,11 +84,10 @@ fuzz_target!(|data: &[u8]| {
     }
 
     // 5. Some oracle deployments will eventually consume per-validator
-    //    records (object shape). Pre-flight that path: any object
-    //    must walk without panicking.
+    //    records (object shape). Pre-flight that path: any object must
+    //    walk without panicking, for any key shape (NUL included).
     if let Some(obj) = v.as_object() {
-        for (k, val) in obj {
-            assert!(!k.contains('\0'), "validator key contains NUL");
+        for val in obj.values() {
             let _ = val.as_str();
             let _ = val.as_array();
         }


### PR DESCRIPTION
Resolves the recurring nightly `fuzz-crash` issues (#44–#56, #58) — all harness defects, not code bugs. See commit for the full root-cause writeup.

- **fuzz_preauth_redeem**: matched `RedeemError` without a `_` arm; the enum became `#[non_exhaustive]`, so it stopped compiling (E0004) → `cargo fuzz run` exited 101 → 'found a crash' with no artifact. Fix: `Err(_) =>`.
- **fuzz_validator_health_oracle**: asserted decoded addresses hold no NUL byte, but a JSON NUL escape is legal; production `refresh_bulk` makes no such assertion. Fix: drop the two content asserts.

Verified: both targets build under `cargo +nightly fuzz build`; the validator target runs its former crashing seed cleanly (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)