### PR TITLE
ci(fuzz): stop misreporting build failures as crashes (protoc + build/run split)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -101,6 +101,12 @@ jobs:
             octra/fuzz
       - name: Install cargo-fuzz
         run: cargo install --locked cargo-fuzz
+      # headscale-api's build script (prost-build) shells out to protoc.
+      # Without it every target fails at BUILD, and until the build/run
+      # split below that was misreported as "found a crash" for all 12
+      # targets, every night, for ~91 nights (~1,000 false issues).
+      - name: Install protoc (headscale-api build dep)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq protobuf-compiler
 
       # Skip the matrix row when workflow_dispatch pinned a single
       # target. We can't dynamically prune the matrix from `inputs`,
@@ -129,6 +135,14 @@ jobs:
           restore-keys: |
             fuzz-corpus-${{ matrix.target }}-
 
+      # Build FIRST, as its own step: a broken build fails the job with
+      # a build error and never reaches the crash-reporting path. A
+      # toolchain or dependency break is a CI bug, not a finding.
+      - name: Build fuzz target
+        if: steps.gate.outputs.skip == '0'
+        working-directory: octra
+        run: cargo +nightly fuzz build "${{ matrix.target }}"
+
       - name: Run fuzz target
         if: steps.gate.outputs.skip == '0'
         id: run
@@ -145,12 +159,22 @@ jobs:
               -timeout=10
           rc=$?
           echo "rc=${rc}" >> "$GITHUB_OUTPUT"
-          # libfuzzer convention: 77 = no crash. Anything else means
-          # a finding (panic / sanitizer / timeout / OOM) and we want
-          # to surface the artifact.
-          if [ "$rc" -ne 0 ] && [ "$rc" -ne 77 ]; then
-            echo "::warning::fuzz target ${{ matrix.target }} reported a finding (exit $rc)"
+          # A finding is defined by what libfuzzer WROTE, not by the exit
+          # code: on a crash/timeout/OOM it drops a crash-*/timeout-*/
+          # oom-*/leak-* file under fuzz/artifacts/<target>/. Exit code
+          # alone conflated "the build broke" and "the runner killed
+          # cargo" with real findings.
+          art="fuzz/artifacts/${{ matrix.target }}"
+          n=$(find "$art" -maxdepth 1 -type f \( -name 'crash-*' -o -name 'timeout-*' -o -name 'oom-*' -o -name 'leak-*' \) 2>/dev/null | wc -l | tr -d ' ')
+          echo "artifacts=${n}" >> "$GITHUB_OUTPUT"
+          if [ "$n" -gt 0 ]; then
+            echo "::warning::fuzz target ${{ matrix.target }} produced ${n} crash artifact(s) (exit $rc)"
             echo "found=1" >> "$GITHUB_OUTPUT"
+          elif [ "$rc" -ne 0 ] && [ "$rc" -ne 77 ]; then
+            # Non-zero with no artifact = infrastructure (killed, disk,
+            # network). Visible as a job error, but NOT a crash issue.
+            echo "::error::fuzz target ${{ matrix.target }} exited $rc with no crash artifact — infrastructure failure, not a finding"
+            echo "found=0" >> "$GITHUB_OUTPUT"
           else
             echo "found=0" >> "$GITHUB_OUTPUT"
           fi

--- a/fuzz/fuzz_targets/fuzz_preauth_redeem.rs
+++ b/fuzz/fuzz_targets/fuzz_preauth_redeem.rs
@@ -86,6 +86,12 @@ fuzz_target!(|data: &[u8]| {
                         // so a wildcard is required (and any future
                         // variant is likewise a non-panic rejection here).
                     }
+                    // RedeemError is #[non_exhaustive] from this crate's
+                    // point of view, so the compiler demands a wildcard.
+                    // A new error kind is still a non-panicking outcome
+                    // for this target: the invariant under test is
+                    // single-use, not the error taxonomy.
+                    Err(_) => {}
                 }
             }
             4 => {

--- a/fuzz/fuzz_targets/fuzz_preauth_redeem.rs
+++ b/fuzz/fuzz_targets/fuzz_preauth_redeem.rs
@@ -73,10 +73,7 @@ fuzz_target!(|data: &[u8]| {
                             // token across the lifetime of this fuzz
                             // input.
                             let fresh = single_use_redeemed.insert(tok.clone());
-                            assert!(
-                                fresh,
-                                "single-use double-redemption: {tok}"
-                            );
+                            assert!(fresh, "single-use double-redemption: {tok}");
                         }
                     }
                     Err(_) => {


### PR DESCRIPTION
## Why

The nightly fuzz job has filed **"fuzz: <target> found a crash"** for all targets, every night, since 2026-06-14 — ~1,100 open issues, **none of them findings**. `headscale-api`'s build script shells out to `protoc`; the runner never had it; every target failed at *build*; and the run step treated any exit code other than 0/77 as a crash.

Scheduled workflows run from `main`, so the fix has to land here — it is otherwise already on `codex/octra-headscale-router-adaptation-20260602`.

## What

- install `protobuf-compiler`
- build each target as its **own step** — a broken build fails the job with a build error and never reaches the crash-reporting path
- decide "found" from what libfuzzer **wrote** (`crash-*`/`timeout-*`/`oom-*`/`leak-*` under `fuzz/artifacts/<target>/`), never from the exit code; a non-zero exit with no artifact is reported as an infrastructure failure, not a finding
- fix the one genuine build break the first clean run surfaced: `fuzz_preauth_redeem` didn't cover the `#[non_exhaustive]` `RedeemError`

## Validation

Manual run [34693812925](https://github.com/androolloyd/octravpn/actions/runs/34693812925) on the feature branch: 10/11 targets built and ran clean, **zero issues filed**; the one failure was the `preauth_redeem` build break above (fixed in the second commit), and it was correctly *not* reported as a crash.

The ~1,100 existing false issues are being closed with an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)